### PR TITLE
Shutdown mp.Manager instead of killing child processes forsibly

### DIFF
--- a/gpuparallel/gpuparallel.py
+++ b/gpuparallel/gpuparallel.py
@@ -1,9 +1,9 @@
 import logging
 from functools import partial
-from multiprocessing import Pool, Manager, Queue
+from multiprocessing import Pool, Manager, Queue, active_children
 from typing import List, Iterable, Optional, Callable, Union, Generator
 
-from gpuparallel.utils import log, import_tqdm, kill_child_processes
+from gpuparallel.utils import log, import_tqdm
 
 
 def _init_worker(gpu_queue: Queue, init_fn: Optional[Callable] = None):
@@ -38,7 +38,7 @@ def _run_task(func: Callable, task_idx, result_queue: Queue, ignore_errors=True)
 class GPUParallel:
     def __init__(self, device_ids: Optional[List[str]] = None, n_gpu: Optional[Union[int, str]] = None,
                  n_workers_per_gpu=1, init_fn: Optional[Callable] = None, preserve_order=True,
-                 progressbar=True, ignore_errors=False, kill_all_children_on_exit=True, debug=False):
+                 progressbar=True, ignore_errors=False, debug=False):
         """
         Parallel execution of functions passed to ``__call__``.
 
@@ -57,7 +57,6 @@ class GPUParallel:
         :param preserve_order: Return values with the same order as input.
         :param progressbar: Allow to use tqdm progressbar.
         :param ignore_errors: Either ignore errors inside tasks or raise them.
-        :param kill_all_children_on_exit: Kill all children of the current process to prevent hangs in the next run.
         :param debug: When this parameter is True, parameters n_gpu and device_ids are ignored.
             Class creates only one worker ([device_id='cuda:0']) and run it in the same process (for better debugging).
 
@@ -68,7 +67,6 @@ class GPUParallel:
         self.preserve_order = preserve_order
         self.progressbar = progressbar
         self.ignore_errors = ignore_errors
-        self.kill_all_children_on_exit = kill_all_children_on_exit
         self.debug_mode = debug
 
         if device_ids is not None:
@@ -82,8 +80,8 @@ class GPUParallel:
             self.device_ids = [f'cuda:{idx}' for idx in range(n_gpu)]
 
         if not self.debug_mode:
-            m = Manager()
-            self.gpu_queue = m.Queue()
+            self._manager = Manager()
+            self.gpu_queue = self._manager.Queue()
             for device_idx in range(self.n_gpu):
                 for idx in range(self.n_workers_per_gpu):
                     worker_id = device_idx * self.n_workers_per_gpu + idx
@@ -93,7 +91,7 @@ class GPUParallel:
             self.pool = Pool(processes=self.n_gpu * self.n_workers_per_gpu, initializer=initializer,
                              maxtasksperchild=None)
 
-            self.result_queue = m.Queue()
+            self.result_queue = self._manager.Queue()
         else:  # debug mode; run init in the same process
             log.warning('Debug mode. All tasks will be run in main process for debug purposes.')
             if init_fn is not None:
@@ -106,15 +104,15 @@ class GPUParallel:
         """
         if not self.debug_mode:
             try:
+                self._manager.shutdown()
                 self.pool.close()
                 self.pool.join()
             except Exception as e:
                 log.warning('Can\'t close and join process pool.', exc_info=True)
 
-        if self.kill_all_children_on_exit:
-            log.info("Kill all children of the current process to prevent hangs in the next run")
-            kill_child_processes()
-            log.info("All children killed")
+        children = active_children()
+        if children:
+            log.warning(f"{len(children)} child processes are still alive after closing the pool.")
 
     def _call_sync(self, tasks: Iterable) -> List:
         log.warning(f'Debug mode is turned on. All tasks will be run in the main process.')

--- a/gpuparallel/utils.py
+++ b/gpuparallel/utils.py
@@ -60,11 +60,3 @@ def import_tqdm(progressbar=True):
         except ImportError:
             log.warning("Can't load tqdm")
     return TqdmStub
-
-def kill_child_processes():
-    parent_id = os.getpid()
-    ps_command = subprocess.Popen("ps -o pid --ppid %d --noheaders" % parent_id, shell=True, stdout=subprocess.PIPE)
-    ps_output = ps_command.stdout.read()
-    retcode = ps_command.wait()
-    for pid_str in ps_output.strip().split("\n")[:-1]:
-        os.kill(int(pid_str), signal.SIGTERM)


### PR DESCRIPTION
mp.Manager holds and does not allow the child processes to terminate, which is why, after deleting the GPUParallel object, the child processes still remain alive. To avoid this, it is also necessary to shutdown the manager.